### PR TITLE
Fix Gradio version issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ emoji==2.14.1
 evaluation==0.0.2
 fastapi==0.123.9
 funasr==1.1.6
-gradio==6.0.2
+gradio==6.1.0
 HyperPyYAML==1.2.2
 jieba==0.42.1
 jiwer==4.0.0


### PR DESCRIPTION
Fix Gradio version issue for gradio_app.py
Before fix:
(tts) root@35zdt2v8kxmt8e:~/GLM-TTS# python -c "import gradio as gr; print(gr.__version__)"
6.0.2
(tts) root@35zdt2v8kxmt8e:~/GLM-TTS# PYTHONPATH=. python tools/gradio_app.py
/root/miniconda3/envs/tts/lib/python3.10/site-packages/jieba/_compat.py:18: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Warning: failed to import ttsfrd, use WeTextProcessing instead
Traceback (most recent call last):
  File "/root/GLM-TTS/tools/gradio_app.py", line 159, in <module>
    with gr.Blocks(title="GLMTTS Inference", theme=gr.themes.Soft()) as app:
  File "/root/miniconda3/envs/tts/lib/python3.10/site-packages/gradio/blocks.py", line 1071, in __init__
    super().__init__(render=False, **kwargs)
TypeError: BlockContext.__init__() got an unexpected keyword argument 'theme'

After fix:
Successfully installed gradio-6.1.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
(tts) root@35zdt2v8kxmt8e:~/GLM-TTS# PYTHONPATH=. python tools/gradio_app.py
/root/miniconda3/envs/tts/lib/python3.10/site-packages/jieba/_compat.py:18: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Warning: failed to import ttsfrd, use WeTextProcessing instead
/root/GLM-TTS/tools/gradio_app.py:159: UserWarning: The parameters have been moved from the Blocks constructor to the launch() method in Gradio 6.0: theme. Please pass these parameters to launch() instead.
  with gr.Blocks(title="GLMTTS Inference", theme="soft") as app:
* Running on local URL:  http://0.0.0.0:8048
* To create a public link, set `share=True` in `launch()`.

